### PR TITLE
Possibly fix bug allowing users to avoid being nicknamed

### DIFF
--- a/src/DiscordMember.js
+++ b/src/DiscordMember.js
@@ -151,7 +151,7 @@ class DiscordMember {
 
 				if (this.discordServer.getSetting('nicknameUsers')) {
 					let nickname = this.getNickname(data);
-					if (this.member.displayName !== nickname) {
+					if (this.member.nickname !== nickname) {
 						await this.member.setNickname(nickname);
 					}
 				}


### PR DESCRIPTION
People would set their Discord user name to their verified roblox username, and then change it and would avoid being nicknamed. This should fix it . . ?